### PR TITLE
fix: async deadlock + missing try/catch (P0 — fixes #21, #20)

### DIFF
--- a/Api.Tests/Controllers/ShopItemCategoryControllerTests.cs
+++ b/Api.Tests/Controllers/ShopItemCategoryControllerTests.cs
@@ -1,11 +1,16 @@
 using Api.Controllers;
 using AutoMapper;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shared.FireStoreDataModels;
 using Shared.HandlelisteModels;
 using Shared.Repository;
+using System.IO;
+using System.Net;
+using System.Text;
 using Xunit;
 
 namespace Api.Tests.Controllers
@@ -232,6 +237,55 @@ namespace Api.Tests.Controllers
             // Assert
             Assert.NotNull(categoryModel.Id);
             Assert.NotEmpty(categoryModel.Name);
+        }
+
+        [Fact]
+        public async Task RunOne_Get_Returns500WithGenericMessage_WhenRepositoryThrows()
+        {
+            // Arrange — repository throws to simulate an unexpected failure
+            var mockLogger = new Mock<ILogger>();
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+
+            var throwingRepo = new Mock<IGenericRepository<ItemCategory>>();
+            throwingRepo.Setup(r => r.Get(It.IsAny<object>()))
+                .ThrowsAsync(new InvalidOperationException("Firestore connection string exposed in error"));
+
+            var controller = new ShopItemCategoryController(mockLoggerFactory.Object, throwingRepo.Object, _mapper);
+
+            var mockContext = new Mock<FunctionContext>();
+            mockContext.Setup(c => c.InstanceServices).Returns(new Mock<IServiceProvider>().Object);
+
+            var responseBody = new MemoryStream();
+            var mockResponse = new Mock<HttpResponseData>(mockContext.Object);
+            mockResponse.SetupProperty(r => r.StatusCode);
+            mockResponse.Setup(r => r.Body).Returns(responseBody);
+            mockResponse.Setup(r => r.Headers).Returns(new HttpHeadersCollection());
+
+            var mockRequest = new Mock<HttpRequestData>(mockContext.Object);
+            mockRequest.Setup(r => r.Method).Returns("GET");
+            mockRequest.Setup(r => r.CreateResponse()).Returns(mockResponse.Object);
+
+            // Act
+            var result = await controller.RunOne(mockRequest.Object, "test-id");
+
+            // Assert — status 500
+            Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+
+            // Assert — response body does NOT leak internal exception details (security constraint S4)
+            responseBody.Seek(0, SeekOrigin.Begin);
+            var body = await new StreamReader(responseBody, Encoding.UTF8).ReadToEndAsync();
+            Assert.DoesNotContain("Firestore connection string exposed", body);
+
+            // Assert — exception was logged via ILogger
+            mockLogger.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => true),
+                    It.IsAny<InvalidOperationException>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
         }
 
         [Theory]

--- a/Api/Controllers/ShopItemCategoryController.cs
+++ b/Api/Controllers/ShopItemCategoryController.cs
@@ -74,27 +74,37 @@ namespace Api.Controllers
         [Function("itemcategory")]
         public async Task<HttpResponseData> RunOne([HttpTrigger(AuthorizationLevel.Anonymous, "get", "delete", Route = "itemcategory/{id}")] HttpRequestData req, object id)
         {
-            var okRespons = req.CreateResponse(HttpStatusCode.OK);
-
-            if (req.Method == "GET")
+            try
             {
-                var itemCategories = await repository.Get(id);
-                if (itemCategories == null)
+                var okRespons = req.CreateResponse(HttpStatusCode.OK);
+
+                if (req.Method == "GET")
                 {
-                    return await GetErroRespons("Could not load items categorys", req);
+                    var itemCategory = await repository.Get(id);
+                    if (itemCategory == null)
+                    {
+                        return await GetErroRespons("Could not load items categorys", req);
+                    }
+                    await okRespons.WriteAsJsonAsync(mapper.Map<ItemCategory>(itemCategory));
+                    return okRespons;
                 }
-                await okRespons.WriteAsJsonAsync(mapper.Map<ItemCategory>(itemCategories));
+                else if (req.Method == "DELETE")
+                {
+                    var deleteResult = await repository.Delete(id);
+                    if (deleteResult)
+                        return req.CreateResponse(HttpStatusCode.NoContent);
+                    else
+                        return await GetErroRespons($"Could not delete item {id}", req);
+                }
 
+                return req.CreateResponse(HttpStatusCode.NotFound);
             }
-            else if (req.Method == "DELETE")
+            catch (System.Exception e)
             {
-                var deleteResult = await repository.Delete(id);
-                if (deleteResult)
-                    return req.CreateResponse(HttpStatusCode.NoContent);
-                else
-                    return await GetErroRespons($"Could not delete item {id}", req);
+                var msg = $"An unexpected error occurred processing itemcategory/{id}, method {req.Method}";
+                _logger.LogError(e, msg);
+                return await GetErroRespons("An unexpected error occurred", req);
             }
-            return req.CreateResponse(HttpStatusCode.NoContent);
         }
     }
 }

--- a/Api/Controllers/ShopsController.cs
+++ b/Api/Controllers/ShopsController.cs
@@ -47,9 +47,9 @@ namespace Api.Controllers
                 }
                 else
                 {
-                    var newShop = req.ReadFromJsonAsync<ShopModel>();
-                    if (newShop.Result == null) return await GetErroRespons("No content in shop body", req);
-                    Shop updatOrInsert = mapper.Map<Shop>(newShop.Result);
+                    var newShop = await req.ReadFromJsonAsync<ShopModel>();
+                    if (newShop == null) return await GetErroRespons("No content in shop body", req);
+                    Shop updatOrInsert = mapper.Map<Shop>(newShop);
                     if (req.Method == "POST")
                     {
                         updatOrInsert = await repository.Insert(updatOrInsert);


### PR DESCRIPTION
## P0 Bug Fixes

### Fix #21 — Replace .Result with await in ShopsController
Eliminates deadlock risk in Azure Functions SynchronizationContext.

### Fix #20 — Add try/catch to ShopItemCategoryController.RunOne
Consistent error handling. Generic error response (security constraint S4), full exception logged via ILogger. Unit test added.

Closes #21
Closes #20