### PR TITLE
fix: register WeekMenu + MealRecipe DI (P0 — fixes #17)

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -34,7 +34,9 @@ namespace ApiIsolated
                         services.AddSingleton<IGenericRepository<Shop>, MemoryGenericRepository<Shop>>();
                         services.AddSingleton<IGenericRepository<FrequentShoppingList>, MemoryGenericRepository<FrequentShoppingList>>();
                         services.AddSingleton<IGenericRepository<MealRecipe>, MemoryGenericRepository<MealRecipe>>();
-                        services.AddSingleton<IGenericRepository<MealIngredient>, MemoryGenericRepository<MealIngredient>>();
+                        services.AddSingleton<IGenericRepository<WeekMenu>, MemoryGenericRepository<WeekMenu>>();
+                        // MealIngredient: embedded in MealRecipe — no separate repository (D3/D9)
+                        // DailyMeal: embedded in WeekMenu — no separate repository (D3)
                     }
                     else
                     {
@@ -45,7 +47,9 @@ namespace ApiIsolated
                         services.AddSingleton<IGenericRepository<Shop>, GoogleFireBaseGenericRepository<Shop>>();
                         services.AddSingleton<IGenericRepository<FrequentShoppingList>, GoogleFireBaseGenericRepository<FrequentShoppingList>>();
                         services.AddSingleton<IGenericRepository<MealRecipe>, GoogleFireBaseGenericRepository<MealRecipe>>();
-                        services.AddSingleton<IGenericRepository<MealIngredient>, GoogleFireBaseGenericRepository<MealIngredient>>();
+                        services.AddSingleton<IGenericRepository<WeekMenu>, GoogleFireBaseGenericRepository<WeekMenu>>();
+                        // MealIngredient: embedded in MealRecipe — no separate repository (D3/D9)
+                        // DailyMeal: embedded in WeekMenu — no separate repository (D3)
                     }
                 })
                 .Build();


### PR DESCRIPTION
## P0 Bug Fix — Meal Features DI Wiring

Adds DI registration for WeekMenu and removes erroneous MealIngredient registration in both DEBUG (MemoryGenericRepository) and production (GoogleFireBaseGenericRepository) blocks.

Changes:
- Added IGenericRepository<WeekMenu> — was missing, causing runtime DI failure
- IGenericRepository<MealRecipe> — already registered, no change needed
- Removed IGenericRepository<MealIngredient> — per decisions D3/D9: embedded, not standalone

Per D3 and D9: MealIngredient and DailyMeal are embedded and do NOT get separate repository registration.

Note: This PR targets squad/16-collection-key-fix (which must merge first).

Depends on #16
Closes #17