### PR TITLE
feat: Pakkestørrelse-visning i handleliste (#76)

### DIFF
--- a/Client/Pages/Meals/OneWeekMenuPage.razor
+++ b/Client/Pages/Meals/OneWeekMenuPage.razor
@@ -191,7 +191,7 @@
                             {
                                 <tr>
                                     <td>@item.Varen?.Name</td>
-                                    <td>@item.Mengde</td>
+                                    <td>@FormatQuantity(item)</td>
                                 </tr>
                             }
                         </tbody>
@@ -213,7 +213,7 @@
                                     {
                                         <tr class="text-muted">
                                             <td>@item.Varen?.Name</td>
-                                            <td>@item.Mengde</td>
+                                            <td>@FormatQuantity(item)</td>
                                             <td class="text-end">
                                                 <button type="button" class="btn btn-sm btn-outline-danger"
                                                         @onclick="@(() => RemoveGeneratedItem(item))"
@@ -606,6 +606,16 @@
         {
             _savingList = false;
         }
+    }
+
+    // #76 — Format quantity with package size: "2 × 500g", fallback to plain number
+    private static string FormatQuantity(ShoppingListItemModel item)
+    {
+        var qty = item.Varen?.StandardPurchaseQuantity ?? 0;
+        var unit = item.Varen?.StandardPurchaseUnit;
+        return (qty > 0 && !string.IsNullOrEmpty(unit))
+            ? $"{item.Mengde} × {qty.ToString("G29")}{unit}"
+            : item.Mengde.ToString();
     }
 
     // #73 — Remove an item from the generated list preview

--- a/Client/Shared/ShoppingListComponents/OneShoppingListItemComponent.razor
+++ b/Client/Shared/ShoppingListComponents/OneShoppingListItemComponent.razor
@@ -5,7 +5,19 @@
     <label>
         @OneShoppingListItem.Varen.Name
     </label>
-    <input @bind-value="OneShoppingListItem.Mengde" />
+    @{
+        var _qty = OneShoppingListItem.Varen?.StandardPurchaseQuantity ?? 0;
+        var _unit = OneShoppingListItem.Varen?.StandardPurchaseUnit;
+        var _hasPackageInfo = _qty > 0 && !string.IsNullOrEmpty(_unit);
+        var _pkgLabel = _hasPackageInfo ? $"× {_qty.ToString("G29")}{_unit}" : null;
+    }
+    <span class="qty-display">
+        <input @bind-value="OneShoppingListItem.Mengde" class="@(_hasPackageInfo ? "qty-input-narrow" : "")" />
+        @if (_hasPackageInfo)
+        {
+            <span class="pkg-size-label" title="@($"{OneShoppingListItem.Mengde} × {_qty.ToString("G29")}{_unit}")">@_pkgLabel</span>
+        }
+    </span>
     <button class="btn btn-sm btn-outline-danger" @onclick="@(e => DeleteVare(OneShoppingListItem))"><i class="fas fa-ban"> </i></button>
 
 </div>

--- a/Client/Shared/ShoppingListComponents/OneShoppingListItemComponent.razor.css
+++ b/Client/Shared/ShoppingListComponents/OneShoppingListItemComponent.razor.css
@@ -1,0 +1,18 @@
+/* Package-size quantity display — #76 */
+.qty-display {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
+}
+
+.qty-input-narrow {
+    width: 3rem;
+    text-align: center;
+}
+
+.pkg-size-label {
+    font-size: 0.85em;
+    color: #6c757d;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Viser 'N × størrelse' i handlelistevarer når StandardPurchaseQuantity er satt på varen.

## Endringer
- **OneShoppingListItemComponent**: Viser \{Mengde} × {qty}{unit}\ (f.eks. \2 × 500g\) når \StandardPurchaseQuantity > 0\ og \StandardPurchaseUnit\ er satt. Faller tilbake til bare tall ellers. Ny scoped CSS-fil for \qty-display\ layout.
- **OneWeekMenuPage**: \FormatQuantity()\ helper bruker samme logikk i den genererte handleliste-forhåndsvisningen (normalvarer og basisvarer).

## Avhengigheter
- Bygger på Glenn sitt arbeid: \WeekMenuController.RunGenerateShoppingList()\ setter \Mengde\ = antall pakker når enheter er kompatible.