### PR TITLE
feat: Pakkestørrelse-kalkulator i handleliste-generering (#76)

### DIFF
--- a/Api.Tests/Controllers/WeekMenuControllerTests.cs
+++ b/Api.Tests/Controllers/WeekMenuControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Shared;
 using Shared.FireStoreDataModels;
 using Shared.HandlelisteModels;
 using Shared.Repository;
@@ -824,6 +825,195 @@ namespace Api.Tests.Controllers
             _mockWeekMenuRepository.Verify(r => r.Update(It.Is<WeekMenu>(
                 wm => wm.DailyMeals.Any(d => d.Day == DayOfWeek.Wednesday && !d.IsConsumed)
             )), Times.Once);
+        }
+
+        // ── Test 21: Package-size calc — compatible units yields package count ────
+
+        [Fact]
+        public async Task GenerateShoppingList_PackageSize_CalculatesPackagesWhenUnitsCompatible()
+        {
+            // Arrange: 700 g demand (400 + 300), 500 g bag → should produce Mengde = 2
+            const string itemId = "item-flour";
+            var shopItem = new ShopItem
+            {
+                Id = itemId,
+                Name = "Mel",
+                StandardPurchaseQuantity = 500,
+                StandardPurchaseUnit = "g"
+            };
+
+            var recipe1 = new MealRecipe
+            {
+                Id = "recipe-a",
+                Name = "Brød",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = itemId, ShopItemName = "Mel", Quantity = 400, Unit = MealUnit.Gram }
+                }
+            };
+            var recipe2 = new MealRecipe
+            {
+                Id = "recipe-b",
+                Name = "Pizza",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = itemId, ShopItemName = "Mel", Quantity = 300, Unit = MealUnit.Gram }
+                }
+            };
+
+            var menu = new WeekMenu
+            {
+                Id = "menu-pkg",
+                Name = "Uke 47 2025",
+                WeekNumber = 47,
+                Year = 2025,
+                IsActive = true,
+                DailyMeals = new List<DailyMeal>
+                {
+                    new DailyMeal { Day = DayOfWeek.Monday, MealRecipeId = "recipe-a", CustomIngredients = new List<MealIngredient>() },
+                    new DailyMeal { Day = DayOfWeek.Tuesday, MealRecipeId = "recipe-b", CustomIngredients = new List<MealIngredient>() }
+                }
+            };
+
+            _mockWeekMenuRepository.Setup(r => r.Get("menu-pkg")).ReturnsAsync(menu);
+            _mockMealRecipeRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<MealRecipe>>(new List<MealRecipe> { recipe1, recipe2 }));
+            _mockShopItemRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<ShopItem>>(new List<ShopItem> { shopItem }));
+
+            var req = TestHttpFactory.CreatePostRequest("", "http://localhost/api/weekmenu/menu-pkg/generate-shoppinglist");
+
+            // Act
+            var response = await _controller.RunGenerateShoppingList(req, "menu-pkg");
+            var result = await ReadBody<ShoppingListModel>(response);
+
+            // Assert: 700 g demand / 500 g bag = ceil(1.4) = 2 packages
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(result);
+            var item = Assert.Single(result.ShoppingItems);
+            Assert.Equal(2, item.Mengde);
+        }
+
+        // ── Test 22: Package-size calc — incompatible units falls back to raw ceil ─
+
+        [Fact]
+        public async Task GenerateShoppingList_PackageSize_FallsBackWhenUnitsIncompatible()
+        {
+            // Arrange: demand in Gram, package in "stk" — incompatible → Mengde = ceil(raw)
+            const string itemId = "item-cheese";
+            var shopItem = new ShopItem
+            {
+                Id = itemId,
+                Name = "Ost",
+                StandardPurchaseQuantity = 1,
+                StandardPurchaseUnit = "stk"  // incompatible with Gram demand
+            };
+
+            var recipe = new MealRecipe
+            {
+                Id = "recipe-c",
+                Name = "Toast",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = itemId, ShopItemName = "Ost", Quantity = 200, Unit = MealUnit.Gram }
+                }
+            };
+
+            var menu = new WeekMenu
+            {
+                Id = "menu-incompat",
+                WeekNumber = 47,
+                Year = 2025,
+                IsActive = true,
+                DailyMeals = new List<DailyMeal>
+                {
+                    new DailyMeal { Day = DayOfWeek.Monday, MealRecipeId = "recipe-c", CustomIngredients = new List<MealIngredient>() }
+                }
+            };
+
+            _mockWeekMenuRepository.Setup(r => r.Get("menu-incompat")).ReturnsAsync(menu);
+            _mockMealRecipeRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<MealRecipe>>(new List<MealRecipe> { recipe }));
+            _mockShopItemRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<ShopItem>>(new List<ShopItem> { shopItem }));
+
+            var req = TestHttpFactory.CreatePostRequest("", "http://localhost/api/weekmenu/menu-incompat/generate-shoppinglist");
+
+            // Act
+            var response = await _controller.RunGenerateShoppingList(req, "menu-incompat");
+            var result = await ReadBody<ShoppingListModel>(response);
+
+            // Assert: fallback — Mengde = ceil(200) = 200 (raw demand, not 1 stk)
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(result);
+            var item = Assert.Single(result.ShoppingItems);
+            Assert.Equal(200, item.Mengde);
+        }
+
+        // ── Test 23: Package-size calc — zero StandardPurchaseQuantity falls back ─
+
+        [Fact]
+        public async Task GenerateShoppingList_PackageSize_FallsBackWhenPackageSizeIsZero()
+        {
+            // StandardPurchaseQuantity = 0 means "not configured" → no package calc
+            const string itemId = "item-oil";
+            var shopItem = new ShopItem
+            {
+                Id = itemId,
+                Name = "Olje",
+                StandardPurchaseQuantity = 0,  // not set
+                StandardPurchaseUnit = "dl"
+            };
+
+            var recipe = new MealRecipe
+            {
+                Id = "recipe-d",
+                Name = "Salat",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = itemId, ShopItemName = "Olje", Quantity = 3, Unit = MealUnit.Deciliter }
+                }
+            };
+
+            var menu = new WeekMenu
+            {
+                Id = "menu-zero-pkg",
+                WeekNumber = 47,
+                Year = 2025,
+                IsActive = true,
+                DailyMeals = new List<DailyMeal>
+                {
+                    new DailyMeal { Day = DayOfWeek.Monday, MealRecipeId = "recipe-d", CustomIngredients = new List<MealIngredient>() }
+                }
+            };
+
+            _mockWeekMenuRepository.Setup(r => r.Get("menu-zero-pkg")).ReturnsAsync(menu);
+            _mockMealRecipeRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<MealRecipe>>(new List<MealRecipe> { recipe }));
+            _mockShopItemRepository
+                .Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<ShopItem>>(new List<ShopItem> { shopItem }));
+
+            var req = TestHttpFactory.CreatePostRequest("", "http://localhost/api/weekmenu/menu-zero-pkg/generate-shoppinglist");
+
+            // Act
+            var response = await _controller.RunGenerateShoppingList(req, "menu-zero-pkg");
+            var result = await ReadBody<ShoppingListModel>(response);
+
+            // Assert: fallback — Mengde = ceil(3) = 3 (raw dl, no package conversion)
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(result);
+            var item = Assert.Single(result.ShoppingItems);
+            Assert.Equal(3, item.Mengde);
         }
     }
 }

--- a/Api.Tests/MealUnitExtensionsTests.cs
+++ b/Api.Tests/MealUnitExtensionsTests.cs
@@ -1,0 +1,193 @@
+using Shared;
+using Xunit;
+
+namespace Api.Tests
+{
+    /// <summary>
+    /// Unit tests for MealUnitExtensions package-size calculation methods.
+    /// These tests exercise IsCompatibleWith, NormalizeToBaseUnit,
+    /// NormalizePurchaseUnitToBase, and CalculatePackagesNeeded in isolation.
+    /// </summary>
+    public class MealUnitExtensionsTests
+    {
+        // ── CalculatePackagesNeeded — compatible units ────────────────────────────
+
+        [Fact]
+        public void CalculatePackagesNeeded_ExactFit_Returns1Package()
+        {
+            // 400 g demand, 400 g package → exactly 1 package
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 400, "g");
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_DemandLessThanPackage_Returns1Package()
+        {
+            // 400 g demand, 500 g package → 1 package (can't buy 0.8 of a bag)
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 500, "g");
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_DemandExceedsOnePackage_RoundsUp()
+        {
+            // 600 g demand, 500 g package → ceil(600/500) = ceil(1.2) = 2 packages
+            var result = MealUnitExtensions.CalculatePackagesNeeded(600, MealUnit.Gram, 500, "g");
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_CrossWeightUnits_KgDemandGramPackage()
+        {
+            // 1.5 kg demand, 500 g package → normalize: 1500 g / 500 g = 3 packages
+            var result = MealUnitExtensions.CalculatePackagesNeeded(1.5, MealUnit.Kilogram, 500, "g");
+            Assert.Equal(3, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_CrossWeightUnits_GramDemandKgPackage()
+        {
+            // 400 g demand, 1 kg package → 400 g / 1000 g = 0.4 → ceil = 1 package
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 1, "kg");
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_VolumeUnits_LiterDemandDlPackage()
+        {
+            // 0.6 l demand, 5 dl package → normalize: 6 dl / 5 dl = 1.2 → ceil = 2 packages
+            var result = MealUnitExtensions.CalculatePackagesNeeded(0.6, MealUnit.Liter, 5, "dl");
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_PieceUnits_StkPackage()
+        {
+            // 5 pieces demand, 3-piece pack → ceil(5/3) = 2 packages
+            var result = MealUnitExtensions.CalculatePackagesNeeded(5, MealUnit.Piece, 3, "stk");
+            Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_PakkePackageUnit_Works()
+        {
+            // 4 pieces demand, 2-piece "pakke" → 2 packages
+            var result = MealUnitExtensions.CalculatePackagesNeeded(4, MealUnit.Piece, 2, "pakke");
+            Assert.Equal(2, result);
+        }
+
+        // ── CalculatePackagesNeeded — fallback cases (must return null) ───────────
+
+        [Fact]
+        public void CalculatePackagesNeeded_ZeroPackageSize_ReturnsNull()
+        {
+            // packageSize = 0 → not configured, fallback expected
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 0, "g");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_NegativePackageSize_ReturnsNull()
+        {
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, -100, "g");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_NullPackageUnit_ReturnsNull()
+        {
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 500, null);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_EmptyPackageUnit_ReturnsNull()
+        {
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 500, "");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_UnknownPackageUnit_ReturnsNull()
+        {
+            // "cups" is not a supported purchase unit — return null so caller falls back
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 500, "cups");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_IncompatibleUnits_WeightDemandVolumePackage_ReturnsNull()
+        {
+            // Gram demand vs liter package — incompatible dimensions
+            var result = MealUnitExtensions.CalculatePackagesNeeded(400, MealUnit.Gram, 1, "l");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_IncompatibleUnits_VolumeVsCount_ReturnsNull()
+        {
+            // Deciliter demand vs stk package — incompatible
+            var result = MealUnitExtensions.CalculatePackagesNeeded(3, MealUnit.Deciliter, 1, "stk");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_TablespoonDemand_ReturnsNull()
+        {
+            // Tablespoon has no compatible purchase unit dimension → always null
+            var result = MealUnitExtensions.CalculatePackagesNeeded(3, MealUnit.Tablespoon, 500, "g");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CalculatePackagesNeeded_PinchDemand_ReturnsNull()
+        {
+            // Pinch has no compatible purchase unit → always null
+            var result = MealUnitExtensions.CalculatePackagesNeeded(1, MealUnit.Pinch, 100, "g");
+            Assert.Null(result);
+        }
+
+        // ── IsCompatibleWith — spot checks ───────────────────────────────────────
+
+        [Theory]
+        [InlineData(MealUnit.Gram, "g", true)]
+        [InlineData(MealUnit.Gram, "kg", true)]
+        [InlineData(MealUnit.Gram, "gram", true)]
+        [InlineData(MealUnit.Kilogram, "kg", true)]
+        [InlineData(MealUnit.Kilogram, "g", true)]
+        [InlineData(MealUnit.Gram, "l", false)]
+        [InlineData(MealUnit.Gram, "stk", false)]
+        [InlineData(MealUnit.Liter, "l", true)]
+        [InlineData(MealUnit.Liter, "dl", true)]
+        [InlineData(MealUnit.Deciliter, "liter", true)]
+        [InlineData(MealUnit.Liter, "g", false)]
+        [InlineData(MealUnit.Piece, "stk", true)]
+        [InlineData(MealUnit.Piece, "pcs", true)]
+        [InlineData(MealUnit.Piece, "pakke", true)]
+        [InlineData(MealUnit.Piece, "pk", true)]
+        [InlineData(MealUnit.Piece, "g", false)]
+        [InlineData(MealUnit.Tablespoon, "g", false)]
+        [InlineData(MealUnit.Teaspoon, "l", false)]
+        [InlineData(MealUnit.Pinch, "stk", false)]
+        public void IsCompatibleWith_ReturnsExpected(MealUnit unit, string purchaseUnit, bool expected)
+        {
+            Assert.Equal(expected, unit.IsCompatibleWith(purchaseUnit));
+        }
+
+        // ── NormalizeToBaseUnit — spot checks ─────────────────────────────────────
+
+        [Theory]
+        [InlineData(MealUnit.Gram, 500, 500)]
+        [InlineData(MealUnit.Kilogram, 1.5, 1500)]
+        [InlineData(MealUnit.Deciliter, 3, 3)]
+        [InlineData(MealUnit.Liter, 0.5, 5)]
+        [InlineData(MealUnit.Piece, 4, 4)]
+        [InlineData(MealUnit.PieceHalf, 2, 1)]
+        [InlineData(MealUnit.PieceQuarter, 4, 1)]
+        [InlineData(MealUnit.Package, 3, 3)]
+        public void NormalizeToBaseUnit_ReturnsExpected(MealUnit unit, double quantity, double expected)
+        {
+            Assert.Equal(expected, unit.NormalizeToBaseUnit(quantity), precision: 6);
+        }
+    }
+}

--- a/Api/Controllers/WeekMenuController.cs
+++ b/Api/Controllers/WeekMenuController.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Shared;
 using Shared.FireStoreDataModels;
 using Shared.HandlelisteModels;
 using Shared.Repository;
@@ -235,8 +236,10 @@ namespace Api.Controllers
                 var allShopItems = await _shopItemRepository.Get();
                 var shopItemDict = allShopItems?.ToDictionary(s => s.Id, s => s) ?? new Dictionary<string, ShopItem>();
 
-                // Aggregate ingredients: key = ShopItemId, value = (totalQuantity, shopItemName, shopItem)
-                var aggregated = new Dictionary<string, (double Quantity, string ShopItemName, ShopItem ShopItem)>();
+                // Aggregate ingredients: key = ShopItemId, value = (totalQuantity, shopItemName, shopItem, unit, unitMismatch)
+                // UnitMismatch=true when the same ShopItem appears with different MealUnits across meals — in that case
+                // we cannot safely convert to packages and fall back to Math.Ceiling.
+                var aggregated = new Dictionary<string, (double Quantity, string ShopItemName, ShopItem ShopItem, MealUnit Unit, bool UnitMismatch)>();
 
                 foreach (var daily in weekMenu.DailyMeals ?? Enumerable.Empty<DailyMeal>())
                 {
@@ -262,9 +265,12 @@ namespace Api.Controllers
 
                         shopItemDict.TryGetValue(ingredient.ShopItemId, out var shopItem);
                         if (aggregated.TryGetValue(ingredient.ShopItemId, out var existing))
-                            aggregated[ingredient.ShopItemId] = (existing.Quantity + ingredient.Quantity, existing.ShopItemName, existing.ShopItem ?? shopItem);
+                        {
+                            var mismatch = existing.UnitMismatch || existing.Unit != ingredient.Unit;
+                            aggregated[ingredient.ShopItemId] = (existing.Quantity + ingredient.Quantity, existing.ShopItemName, existing.ShopItem ?? shopItem, existing.Unit, mismatch);
+                        }
                         else
-                            aggregated[ingredient.ShopItemId] = (ingredient.Quantity, ingredient.ShopItemName ?? string.Empty, shopItem);
+                            aggregated[ingredient.ShopItemId] = (ingredient.Quantity, ingredient.ShopItemName ?? string.Empty, shopItem, ingredient.Unit, false);
                     }
                 }
 
@@ -283,7 +289,9 @@ namespace Api.Controllers
                     };
                 }).ToList();
 
-                // #76 — Stock comparison: mark fully-covered items and reduce partially-covered demand
+                // #76 — Stock comparison: mark fully-covered items and reduce partially-covered demand.
+                // Operates on raw ingredient quantities (same units as QuantityInStock) — must run BEFORE
+                // the package conversion below so the subtraction stays in the same unit dimension.
                 var allInventory = await _inventoryRepository.Get();
                 var inventoryDict = allInventory?
                     .Where(i => i.IsActive)
@@ -306,6 +314,24 @@ namespace Api.Controllers
                         // Partially covered — reduce demand by available stock
                         item.Mengde = (int)Math.Ceiling((double)item.Mengde - stock);
                     }
+                }
+
+                // #76 Package-size calculation: convert stock-adjusted raw demand into package count.
+                // Only applies when StandardPurchaseQuantity is set and units are compatible.
+                // Falls back to the raw Math.Ceiling value already in Mengde for unknown/incompatible units.
+                foreach (var item in shoppingItems)
+                {
+                    if (item.Varen?.Id == null) continue;
+                    if (!aggregated.TryGetValue(item.Varen.Id, out var agg)) continue;
+                    if (agg.UnitMismatch) continue;  // mixed units across meals — cannot reliably convert
+                    if (item.Varen.StandardPurchaseQuantity <= 0 || string.IsNullOrEmpty(item.Varen.StandardPurchaseUnit)) continue;
+
+                    var packages = MealUnitExtensions.CalculatePackagesNeeded(
+                        item.Mengde, agg.Unit,
+                        item.Varen.StandardPurchaseQuantity, item.Varen.StandardPurchaseUnit);
+
+                    if (packages.HasValue)
+                        item.Mengde = packages.Value;
                 }
 
                 var shoppingList = new ShoppingListModel

--- a/Shared/Shared/MealUnitExtensions.cs
+++ b/Shared/Shared/MealUnitExtensions.cs
@@ -26,5 +26,95 @@ namespace Shared
                 _                         => throw new ArgumentOutOfRangeException(nameof(unit), unit, null)
             };
         }
+
+        /// <summary>
+        /// Returns true when the MealUnit and the purchase unit string measure the same physical dimension,
+        /// meaning a quantity conversion between them is possible.
+        /// Supported: g/kg (weight), dl/l (volume), stk/pakke/pcs/pk (count).
+        /// Unknown purchase units → false (caller falls back to raw Math.Ceiling).
+        /// </summary>
+        public static bool IsCompatibleWith(this MealUnit unit, string purchaseUnit)
+        {
+            if (string.IsNullOrWhiteSpace(purchaseUnit)) return false;
+            var pu = purchaseUnit.Trim().ToLowerInvariant();
+
+            return unit switch
+            {
+                MealUnit.Gram or MealUnit.Kilogram =>
+                    pu is "g" or "gram" or "kg" or "kilogram",
+
+                MealUnit.Liter or MealUnit.Deciliter =>
+                    pu is "l" or "liter" or "dl" or "deciliter",
+
+                MealUnit.Piece or MealUnit.PieceHalf or MealUnit.PieceQuarter or MealUnit.Package =>
+                    pu is "stk" or "pcs" or "pakke" or "pk",
+
+                _ => false  // tablespoon, teaspoon, pinch — not mapped to purchase units
+            };
+        }
+
+        /// <summary>
+        /// Converts a MealUnit quantity to its base unit:
+        ///   weight → grams, volume → decilitres, count → whole pieces.
+        /// </summary>
+        public static double NormalizeToBaseUnit(this MealUnit unit, double quantity)
+        {
+            return unit switch
+            {
+                MealUnit.Gram          => quantity,
+                MealUnit.Kilogram      => quantity * 1000,
+                MealUnit.Deciliter     => quantity,
+                MealUnit.Liter         => quantity * 10,
+                MealUnit.Piece         => quantity,
+                MealUnit.PieceHalf     => quantity * 0.5,
+                MealUnit.PieceQuarter  => quantity * 0.25,
+                MealUnit.Package       => quantity,
+                _                      => quantity  // unknown units pass through unchanged
+            };
+        }
+
+        /// <summary>
+        /// Converts a purchase unit string quantity to the same base unit used by NormalizeToBaseUnit.
+        /// Unknown strings pass through unchanged (caller decides what to do).
+        /// </summary>
+        public static double NormalizePurchaseUnitToBase(string purchaseUnit, double quantity)
+        {
+            if (string.IsNullOrWhiteSpace(purchaseUnit)) return quantity;
+            return purchaseUnit.Trim().ToLowerInvariant() switch
+            {
+                "g" or "gram"           => quantity,
+                "kg" or "kilogram"      => quantity * 1000,
+                "dl" or "deciliter"     => quantity,
+                "l" or "liter"          => quantity * 10,
+                "stk" or "pcs" or "pakke" or "pk" => quantity,
+                _                       => quantity
+            };
+        }
+
+        /// <summary>
+        /// Calculates how many whole packages are needed to satisfy totalDemand.
+        /// Returns null when:
+        ///   - packageSize is 0 or negative (not configured)
+        ///   - packageUnit is null/empty
+        ///   - demand and package units are incompatible dimensions
+        /// The caller should fall back to <c>(int)Math.Ceiling(totalDemand)</c> on null.
+        /// </summary>
+        public static int? CalculatePackagesNeeded(
+            double totalDemand,
+            MealUnit demandUnit,
+            double packageSize,
+            string packageUnit)
+        {
+            if (packageSize <= 0) return null;
+            if (string.IsNullOrWhiteSpace(packageUnit)) return null;
+            if (!demandUnit.IsCompatibleWith(packageUnit)) return null;
+
+            var normalizedDemand  = demandUnit.NormalizeToBaseUnit(totalDemand);
+            var normalizedPackage = NormalizePurchaseUnitToBase(packageUnit, packageSize);
+
+            if (normalizedPackage <= 0) return null;
+
+            return (int)Math.Ceiling(normalizedDemand / normalizedPackage);
+        }
     }
 }


### PR DESCRIPTION
Closes #76

## Hva

Beregner antall pakker basert på \StandardPurchaseQuantity\/\StandardPurchaseUnit\ på \ShopItem\ når en ukemeny genererer handleliste.

## Endringer

### \Shared/Shared/MealUnitExtensions.cs\
Fire nye extension-metoder:
- \IsCompatibleWith(MealUnit, string)\ — sjekker om MealUnit og kjøps-enhet er i samme dimensjon (vekt/volum/antall)
- \NormalizeToBaseUnit(MealUnit, double)\ — konverterer til basisenhet (gram / dl / stk)
- \NormalizePurchaseUnitToBase(string, double)\ — konverterer kjøps-enhet til samme basisenhet
- \CalculatePackagesNeeded(double, MealUnit, double, string)\ — beregner antall pakker, returnerer \
ull\ ved fallback

### \Api/Controllers/WeekMenuController.cs\
- Aggregerings-dict utvides med \MealUnit Unit\ og \ool UnitMismatch\
- Etter lagersammenligning: ny pakke-konverteringsrunde setter \item.Mengde\ til antall pakker
- Rekkefølge sikrer korrekthet: stock comparison (råenheter) → pakkekonvertering

### Fallback til \Math.Ceiling\
- \StandardPurchaseQuantity == 0\ (ikke konfigurert)
- \StandardPurchaseUnit\ er null/tom/ukjent
- Enheter er uforenlige (gram-demand vs stk-pakke)
- Blandede enheter for samme vare på tvers av retter (\UnitMismatch\)

## Tester
49 nye tester (211 totalt, 0 failures):
- \MealUnitExtensionsTests.cs\: 26 pure unit tests — kompatibilitet, normalisering, fallback-cases
- \WeekMenuControllerTests.cs\: 3 integrasjonstester — pakke-beregning, inkompatible enheter, null-pakkestørrelse