### PR TITLE
feat: #72a smart menu suggestion engine (backend)

### DIFF
--- a/.squad/agents/blair/history.md
+++ b/.squad/agents/blair/history.md
@@ -689,4 +689,23 @@ All 5 individual PRs closed with reference to PR #94.
 - Added a per-row `Fjern` action for the “🤔 Dette har du kanskje i skapet” table via `RemovePantryItem(ShoppingListItemModel)` so users can drop probable pantry items before saving.
 - Kept `_scalingApplied` notice above the groups and retained the explicit save filter `_generatedList.ShoppingItems = _generatedList.ShoppingItems.Where(i => !i.IsLikelyNotNeeded).ToList();` so both maybe-items and inventory-covered items stay out of the persisted shopping list.
 - Group 3 (`✅ Dette har du i skapet`) is informational only, rendered with success/muted styling and never saved.
- 
+
+### 2025-01-01 — Issue #26: Nav Dropdown CSS :hover → @onclick ✅ COMPLETE
+
+**What changed**:
+- `NewNavComponent.razor`: Added `tabindex="0"` to trigger span for keyboard focusability
+- Fixed `aria-expanded` to emit lowercase `true`/`false` via `.ToString().ToLower()`
+- Added `@onkeydown="HandleAdminKeyDown"` — Enter/Space toggles, Escape closes
+- Added transparent `.dropdown-backdrop` overlay div (`@if (_adminOpen)`) for click-away close
+- Added `CloseAdminMenu()` and `HandleAdminKeyDown(KeyboardEventArgs)` C# methods
+- `app.css`: Removed `:hover` from dropdown visibility selectors; visibility now controlled exclusively by `.open` class
+- Added `.dropdown-backdrop` CSS rule (`position:fixed; inset:0; z-index:999`)
+
+**Key decisions**:
+- Used conditional `@if (_adminOpen)` backdrop div instead of JS interop — keeps everything in Blazor, no IJSRuntime dependency
+- Arrow rotation kept on `.open` class only (removed `:hover` rotation for consistency with onclick-only model)
+- `@onclick:stopPropagation="true"` on trigger prevents the nav div's `@onclick="ToggleNavMenu"` from firing unexpectedly
+
+**Files**: `Client/Shared/NewNavComponent.razor`, `Client/wwwroot/css/app.css`
+**PR**: #95 → `integration/sprint-2-fixes`
+

--- a/.squad/agents/peter/history.md
+++ b/.squad/agents/peter/history.md
@@ -572,3 +572,47 @@ All Phase 1–5 implementation issues commented with delivery summary and closed
 - OwnerId isolation (#66) is partially addressed structurally but not enforced — remains on hold per D2 v1 decision until auth hardening sprint.
 - Moq pattern finding: `Task<ICollection<T>>` in `.ReturnsAsync()` requires explicit generic parameter — documented in test files and PR description.
 - Decision record filed: `.squad/decisions/inbox/peter-pr-opened.md`
+
+## 2026-XX-XX — Sprint 2 Issue Audit (#74, #75, #76, #72 Decomposition) ✅
+
+**Requested by:** Daniel Aase (triage of "fixed" but still-open issues with `go:needs-research` labels)
+
+### Audit Findings
+
+**#74 (Mark daily meals as consumed)** — 50% Complete
+- ✅ Backend **fully implemented**: `ConsumeMeal` + `UnConsumeMeal` endpoints, deduction logic, inventory guards
+- ❌ Frontend **missing**: No "Mark as eaten" button in `OneWeekMenuPage.razor`, no IsConsumed state UI
+- **Lesson:** Backend-only features are invisible to users. This was marked "fixed" but the UI gap means it's not shipped.
+
+**#75 (Meal-sourced auto-stock on list completion)** — 60% Complete
+- ✅ Backend hook exists: `ShoppingListController.PUT` detects `IsDone: false→true` and auto-increments inventory
+- ✅ Selective tracking works: `StockBehaviour.Track` enum controls which items are tracked
+- ❌ Missing: `ShoppingListItemModel.IsMealSourced` property to distinguish meal-generated items from user-added items
+- **Lesson:** The hook is over-broad (auto-stocks ALL tracked items). For true issue #75 intent, we need a tagging mechanism. Quick 1-hour fix (add 2 properties + update generate endpoint).
+
+**#76 (Purchase unit sizes)** — 80% Complete
+- ✅ Data model **fully present**: `StandardPurchaseQuantity` + `StandardPurchaseUnit` on both Firestore and DTO models
+- ✅ UI already implemented: Three-section display in `OneWeekMenuPage.razor` (buy / maybe / have)
+- ❓ Logic unclear: `generate-shoppinglist` endpoint likely not using purchase units for smart comparison yet. Needs verification in `WeekMenuController.RunGenerateShoppingList()`.
+- **Lesson:** "Fields exist" != "feature works." Field existence without comparison logic is an incomplete feature. Must verify endpoint logic against spec.
+
+**#72 (Smart suggestion engine)** — Not Started
+- Decomposed into 4 sub-tasks:
+  - **#72a (Core engine):** Fetch last 2 weeks, filter used meals, apply category balance → return 7 suggestions. Medium, no blocker.
+  - **#72b (Freshness pairing):** Detect partial-use ingredients, pair recipes to use them same week. Large, depends on #72a + new `ShopItem.IsFresh` property.
+  - **#72c (UI suggestion panel):** Button in `OneWeekMenuPage.razor`, modal with suggestions. Medium, depends on #72a.
+  - **#72d (Statistics dashboard):** Optional future: show usage frequency + category pie chart. Medium, depends on #72a.
+- **Recommendation:** Ship #72a + #72c together (core + UI), defer #72b (freshness) and #72d (stats) to phase 2.
+- **Lesson:** Breaking down large features before implementation clarifies dependencies and unblocks parallel work.
+
+### Decision Record
+
+- Audit output filed at `.squad/decisions/inbox/peter-sprint2-triage.md`
+- Recommendation: Focus Sprint 2 on #74 UI + #75 tagging + #76 verification before marking issues closed
+- #72 decomposition ready for Sprint 3 planning
+
+### Key Learning
+
+- **"Fixed" is ambiguous — distinguish between "data model complete" and "feature shipped."** #75 data hook exists but tagging doesn't, #76 fields exist but logic unverified, #74 backend done but UI missing. Always ask: "What would a user see if they tried to use this right now?" If the answer is "nothing," it's not shipped yet.
+- **Audit often reveals scope creep vs. scope gap:** #74 was originally scoped as a full feature but implementation split implementation across layers. #75 scope was narrower than implementation (hook auto-stocks all items, not just meal-sourced). #76 scope matches implementation partially (model OK, logic TBD).
+- **Dependencies within a single issue matter:** #72 can't ship #72b (freshness pairing) without #72a (core engine). Breaking down before sprint planning prevents starting on the wrong sub-task.

--- a/Api/Controllers/WeekMenuController.cs
+++ b/Api/Controllers/WeekMenuController.cs
@@ -8,9 +8,11 @@ using Shared.HandlelisteModels;
 using Shared.Repository;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace Api.Controllers
 {
@@ -305,7 +307,8 @@ namespace Api.Controllers
                     {
                         Varen = varen,
                         Mengde = (int)Math.Ceiling(kvp.Value.Quantity),
-                        IsDone = false
+                        IsDone = false,
+                        IsMealSourced = true
                     };
                 }).ToList();
 

--- a/Api/Controllers/WeekMenuController.cs
+++ b/Api/Controllers/WeekMenuController.cs
@@ -305,7 +305,8 @@ namespace Api.Controllers
                     {
                         Varen = varen,
                         Mengde = (int)Math.Ceiling(kvp.Value.Quantity),
-                        IsDone = false
+                        IsDone = false,
+                        IsMealSourced = true
                     };
                 }).ToList();
 

--- a/Api/Controllers/WeekMenuController.cs
+++ b/Api/Controllers/WeekMenuController.cs
@@ -216,6 +216,141 @@ namespace Api.Controllers
             }
         }
 
+        // #72a — Suggest a balanced 7-day meal plan based on recent history and category targets
+        [Function("weekmenu-suggest")]
+        public async Task<HttpResponseData> SuggestMenu(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "weekmenu/suggest")] HttpRequestData req)
+        {
+            try
+            {
+                // Parse optional weekNumber / year from query string; default to current ISO week
+                var qs = HttpUtility.ParseQueryString(req.Url.Query);
+                var today = DateTime.UtcNow;
+                int currentWeek = ISOWeek.GetWeekOfYear(today);
+                int currentYear = today.Year;
+
+                if (!int.TryParse(qs["weekNumber"], out int targetWeek)) targetWeek = currentWeek;
+                if (!int.TryParse(qs["year"], out int targetYear)) targetYear = currentYear;
+
+                // Collect the two preceding ISO week numbers (handles year boundary)
+                var recentWeeks = GetPreviousWeeks(targetWeek, targetYear, 2);
+
+                // Fetch all week menus and filter to the history window
+                var allMenus = await _repository.Get() ?? new List<WeekMenu>();
+                var recentMenus = allMenus
+                    .Where(m => m.IsActive && recentWeeks.Any(w => w.Week == m.WeekNumber && w.Year == m.Year))
+                    .ToList();
+
+                // Collect recipe IDs used in the history window
+                var recentlyUsedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var menu in recentMenus)
+                {
+                    foreach (var daily in menu.DailyMeals ?? Enumerable.Empty<DailyMeal>())
+                    {
+                        if (!string.IsNullOrEmpty(daily.MealRecipeId))
+                            recentlyUsedIds.Add(daily.MealRecipeId);
+                    }
+                }
+
+                // Fetch all active meals; guard against null Id (legacy Firestore documents)
+                var allMeals = await _mealRepository.Get() ?? new List<MealRecipe>();
+                var activeMeals = allMeals
+                    .Where(m => m.IsActive && m.Id != null)
+                    .ToList();
+
+                if (!activeMeals.Any())
+                {
+                    var emptyResp = req.CreateResponse(HttpStatusCode.OK);
+                    await emptyResp.WriteAsJsonAsync(new List<MealRecipeModel>());
+                    return emptyResp;
+                }
+
+                // Celebration meals are always eligible regardless of recent history
+                var eligible = activeMeals
+                    .Where(m => m.Category == Shared.FireStoreDataModels.MealCategory.Celebration
+                                || !recentlyUsedIds.Contains(m.Id))
+                    .OrderByDescending(m => m.PopularityScore)
+                    .ToList();
+
+                // Target category distribution for a 7-day plan
+                var targets = new List<(Shared.FireStoreDataModels.MealCategory Category, int Count)>
+                {
+                    (Shared.FireStoreDataModels.MealCategory.Fish,     2),
+                    (Shared.FireStoreDataModels.MealCategory.Chicken,  1),
+                    (Shared.FireStoreDataModels.MealCategory.Pasta,    1),
+                    (Shared.FireStoreDataModels.MealCategory.KidsLike, 1),
+                    (Shared.FireStoreDataModels.MealCategory.Meat,     1)
+                    // Remaining slot filled from any category by popularity
+                };
+
+                var suggestions = new List<MealRecipe>();
+                var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                // Fill targeted category slots (highest-popularity within each category wins)
+                foreach (var (cat, count) in targets)
+                {
+                    var picks = eligible
+                        .Where(m => m.Category == cat && !used.Contains(m.Id))
+                        .Take(count);
+                    foreach (var pick in picks)
+                    {
+                        suggestions.Add(pick);
+                        used.Add(pick.Id);
+                    }
+                }
+
+                // Fill remaining slots up to 7 from highest-popularity eligible meals
+                var remaining = eligible
+                    .Where(m => !used.Contains(m.Id))
+                    .Take(7 - suggestions.Count);
+                foreach (var r in remaining)
+                {
+                    suggestions.Add(r);
+                    used.Add(r.Id);
+                }
+
+                // Fallback: if the eligible pool is exhausted, allow recently-used meals to fill the plan
+                if (suggestions.Count < 7)
+                {
+                    var fallback = activeMeals
+                        .Where(m => !used.Contains(m.Id))
+                        .OrderByDescending(m => m.PopularityScore)
+                        .Take(7 - suggestions.Count);
+                    suggestions.AddRange(fallback);
+                }
+
+                var models = _mapper.Map<List<MealRecipeModel>>(suggestions);
+                var response = req.CreateResponse(HttpStatusCode.OK);
+                await response.WriteAsJsonAsync(models);
+                return response;
+            }
+            catch (Exception e)
+            {
+                var msg = "Something went wrong generating menu suggestions";
+                _logger.LogError(e, msg);
+                return await GetErroRespons(msg, req);
+            }
+        }
+
+        /// <summary>Returns the <paramref name="count"/> ISO weeks immediately before the given week/year pair.</summary>
+        private static List<(int Week, int Year)> GetPreviousWeeks(int weekNumber, int year, int count)
+        {
+            var result = new List<(int, int)>();
+            int w = weekNumber;
+            int y = year;
+            for (int i = 0; i < count; i++)
+            {
+                w--;
+                if (w < 1)
+                {
+                    y--;
+                    w = ISOWeek.GetWeeksInYear(y);
+                }
+                result.Add((w, y));
+            }
+            return result;
+        }
+
         [Function("weekmenugenerateshoppinglist")]
         public async Task<HttpResponseData> RunGenerateShoppingList([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "weekmenu/{id}/generate-shoppinglist")] HttpRequestData req, string id)
         {

--- a/Client/Common/ISettings.cs
+++ b/Client/Common/ISettings.cs
@@ -42,7 +42,8 @@ namespace BlazorApp.Client.Common
                 { "portionrules", "api/portionrules" },
                 { "weekmenuconsume", "api/weekmenu" },
                 { "weekmenuswap", "api/weekmenu" },
-                { "weekmenuunconsume", "api/weekmenu" }
+                { "weekmenuunconsume", "api/weekmenu" },
+                { "weekmenusuggest", "api/weekmenu/suggest" }
             };
         }
         public string GetApiUrl(ShoppingListKeysEnum key)

--- a/Client/Common/ShoppingListKeysEnum.cs
+++ b/Client/Common/ShoppingListKeysEnum.cs
@@ -35,6 +35,8 @@ namespace BlazorApp.Client.Common
         WeekMenuConsume = 22,
         WeekMenuSwap = 23,
         // #81 — Undo consume
-        WeekMenuUnconsume = 24
+        WeekMenuUnconsume = 24,
+        // #72a — Suggest a 7-day meal plan
+        WeekMenuSuggest = 25
     }
 }

--- a/Shared/Shared/FireStoreDataModels/ShoppingListItem.cs
+++ b/Shared/Shared/FireStoreDataModels/ShoppingListItem.cs
@@ -21,5 +21,9 @@ namespace Shared.FireStoreDataModels
         // #76 — Set by generate-shoppinglist when inventory fully covers this item's demand
         [FirestoreProperty]
         public bool IsLikelyNotNeeded { get; set; }
+
+        // #75 — True when this item was added via WeekMenu generate-shoppinglist
+        [FirestoreProperty]
+        public bool IsMealSourced { get; set; }
     }
 }

--- a/Shared/Shared/HandlelisteModels/ShoppingListItemModel.cs
+++ b/Shared/Shared/HandlelisteModels/ShoppingListItemModel.cs
@@ -16,5 +16,8 @@ namespace Shared.HandlelisteModels
 
         // Set by generate-shoppinglist when inventory quantity fully covers this item's demand
         public bool IsInventoryCovered { get; set; }
+
+        // #75 — True when this item was added via WeekMenu generate-shoppinglist
+        public bool IsMealSourced { get; set; }
     }
 }


### PR DESCRIPTION
Part of #72

Adds GET /weekmenu/suggest endpoint to WeekMenuController. Returns 7 MealRecipeModel suggestions based on:
- History exclusion: no repeat of meals used in last 2 weeks (2-week ISO window)
- Celebration category always eligible regardless of recent use
- Category balance: 2 fish, 1 poultry, 1 pasta/kjøttdeig, 1 kids, 1 meat, remainder by popularity
- Popularity: higher PopularityScore preferred among eligible meals
- Edge cases: insufficient meals (fallback to recently-used), no history (top 7 by score), empty library (200 OK + empty list)

Also adds:
- \WeekMenuSuggest = 25\ to \ShoppingListKeysEnum\
- \weekmenusuggest -> api/weekmenu/suggest\ to \ISettings\ (ready for Blair #72c)