### PR TITLE
feat: #76 purchase unit comparison in shopping list generation

### DIFF
--- a/Api.Tests/Controllers/WeekMenuControllerTests.cs
+++ b/Api.Tests/Controllers/WeekMenuControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Shared;
 using Shared.FireStoreDataModels;
 using Shared.HandlelisteModels;
 using Shared.Repository;
@@ -702,6 +703,151 @@ namespace Api.Tests.Controllers
             Assert.NotNull(result);
             Assert.Single(result.ShoppingItems);
             Assert.True(result.ShoppingItems.Single().Varen.IsBasic);
+        }
+
+        // ── Test 16: Cross-dimension inventory coverage via StandardPurchaseQuantity ──
+
+        [Fact]
+        public async Task GenerateShoppingList_CrossDimensionInventory_MarksItemCovered_ViaStandardPurchaseQuantity()
+        {
+            // Arrange: recipe demands 400 g of carrots; inventory holds 1 bag (Package).
+            // StandardPurchaseQuantity = 1000, StandardPurchaseUnit = "g"
+            // → 1 bag × 1000 g/bag = 1000 g ≥ 400 g → IsInventoryCovered = true
+            const string carrotId = "item-carrots";
+            var shopItem = new ShopItem
+            {
+                Id = carrotId,
+                Name = "Gulrøtter",
+                StandardPurchaseQuantity = 1000,
+                StandardPurchaseUnit = "g"
+            };
+
+            var recipe = new MealRecipe
+            {
+                Id = "recipe-carrot",
+                Name = "Gulrotsuppe",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = carrotId, ShopItemName = "Gulrøtter", Quantity = 400, Unit = MealUnit.Gram }
+                }
+            };
+
+            var menu = new WeekMenu
+            {
+                Id = "menu-carrot",
+                WeekNumber = 50,
+                Year = 2025,
+                IsActive = true,
+                DailyMeals = new List<DailyMeal>
+                {
+                    new DailyMeal { Day = DayOfWeek.Monday, MealRecipeId = recipe.Id, CustomIngredients = new List<MealIngredient>() }
+                }
+            };
+
+            var inventoryItem = new InventoryItem
+            {
+                Id = "inv-1",
+                ShopItemId = carrotId,
+                QuantityInStock = 1,           // 1 bag (package)
+                Unit = MealUnit.Package,
+                IsActive = true
+            };
+
+            _mockWeekMenuRepository.Setup(r => r.Get(menu.Id)).ReturnsAsync(menu);
+            _mockMealRecipeRepository.Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<MealRecipe>>(new List<MealRecipe> { recipe }));
+            _mockShopItemRepository.Setup(r => r.Get())
+                .ReturnsAsync(new List<ShopItem> { shopItem });
+            _mockInventoryRepository.Setup(r => r.Get())
+                .ReturnsAsync(new List<InventoryItem> { inventoryItem });
+
+            var req = TestHttpFactory.CreatePostRequest("", $"http://localhost/api/weekmenu/{menu.Id}/generate-shoppinglist");
+
+            // Act
+            var response = await _controller.RunGenerateShoppingList(req, menu.Id);
+            var result = await ReadBody<ShoppingListModel>(response);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(result);
+            Assert.Single(result.ShoppingItems);
+            var item = result.ShoppingItems.Single();
+            Assert.True(item.IsInventoryCovered, "1 bag (1000 g) should fully cover 400 g demand");
+            Assert.True(item.IsLikelyNotNeeded, "Fully covered item must be marked as likely not needed");
+        }
+
+        [Fact]
+        public async Task GenerateShoppingList_CrossDimensionInventory_PartialCoverage_ReducesDemand()
+        {
+            // Arrange: recipe demands 2500 g of potatoes; inventory holds 2 bags.
+            // StandardPurchaseQuantity = 1000, StandardPurchaseUnit = "g"
+            // → 2 bags × 1000 g/bag = 2000 g < 2500 g → partial.
+            // After stock subtraction (500 g remaining), package-size conversion gives ceil(500/1000) = 1 bag.
+            const string potatoId = "item-potatoes";
+            var shopItem = new ShopItem
+            {
+                Id = potatoId,
+                Name = "Poteter",
+                StandardPurchaseQuantity = 1000,
+                StandardPurchaseUnit = "g"
+            };
+
+            var recipe = new MealRecipe
+            {
+                Id = "recipe-potato",
+                Name = "Potetsuppe",
+                IsActive = true,
+                Ingredients = new List<MealIngredient>
+                {
+                    new MealIngredient { ShopItemId = potatoId, ShopItemName = "Poteter", Quantity = 2500, Unit = MealUnit.Gram }
+                }
+            };
+
+            var menu = new WeekMenu
+            {
+                Id = "menu-potato",
+                WeekNumber = 51,
+                Year = 2025,
+                IsActive = true,
+                DailyMeals = new List<DailyMeal>
+                {
+                    new DailyMeal { Day = DayOfWeek.Monday, MealRecipeId = recipe.Id, CustomIngredients = new List<MealIngredient>() }
+                }
+            };
+
+            var inventoryItem = new InventoryItem
+            {
+                Id = "inv-2",
+                ShopItemId = potatoId,
+                QuantityInStock = 2,           // 2 bags = 2000 g
+                Unit = MealUnit.Package,
+                IsActive = true
+            };
+
+            _mockWeekMenuRepository.Setup(r => r.Get(menu.Id)).ReturnsAsync(menu);
+            _mockMealRecipeRepository.Setup(r => r.Get())
+                .Returns(Task.FromResult<ICollection<MealRecipe>>(new List<MealRecipe> { recipe }));
+            _mockShopItemRepository.Setup(r => r.Get())
+                .ReturnsAsync(new List<ShopItem> { shopItem });
+            _mockInventoryRepository.Setup(r => r.Get())
+                .ReturnsAsync(new List<InventoryItem> { inventoryItem });
+
+            var req = TestHttpFactory.CreatePostRequest("", $"http://localhost/api/weekmenu/{menu.Id}/generate-shoppinglist");
+
+            // Act
+            var response = await _controller.RunGenerateShoppingList(req, menu.Id);
+            var result = await ReadBody<ShoppingListModel>(response);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(result);
+            Assert.Single(result.ShoppingItems);
+            var item = result.ShoppingItems.Single();
+            Assert.False(item.IsInventoryCovered, "Partial coverage should not mark as fully covered");
+            // 2500 g demand, 2000 g in stock (2 bags × 1000 g) → 500 g shortfall.
+            // Package-size conversion then rounds up: ceil(500/1000) = 1 bag to buy.
+            Assert.Equal(1, item.Mengde);
         }
 
         // ── Test 15: Generate returns 404 when WeekMenu not found ─────────────────

--- a/Api/Controllers/WeekMenuController.cs
+++ b/Api/Controllers/WeekMenuController.cs
@@ -310,8 +310,9 @@ namespace Api.Controllers
                 }).ToList();
 
                 // #76 — Stock comparison: mark fully-covered items and reduce partially-covered demand.
-                // Operates on raw ingredient quantities (same units as QuantityInStock) — must run BEFORE
-                // the package conversion below so the subtraction stays in the same unit dimension.
+                // Runs BEFORE package-size conversion so demand subtraction stays in the same unit dimension.
+                // Cross-dimension case (e.g. inventory in Package, recipe in Gram): converts inventory
+                // to recipe base units via StandardPurchaseQuantity before comparing.
                 var allInventory = await _inventoryRepository.Get();
                 var inventoryDict = allInventory?
                     .Where(i => i.IsActive && i.ShopItemId != null)
@@ -324,6 +325,48 @@ namespace Api.Controllers
                     if (item.Varen?.Id == null) continue;
                     if (!inventoryDict.TryGetValue(item.Varen.Id, out var inv)) continue;
 
+                    bool hasAgg = aggregated.TryGetValue(item.Varen.Id, out var agg);
+
+                    // Cross-dimension smart comparison:
+                    // When inventory is stored in packages/units but the recipe demands weight or volume,
+                    // multiply inventory count by StandardPurchaseQuantity to obtain recipe-compatible units.
+                    // Example: inv=1 bag (Package), StandardPurchaseQuantity=1000, StandardPurchaseUnit="g",
+                    //          recipe needs 400 g → effectiveStock = 1×1000 = 1000 g ≥ 400 g → covered.
+                    if (hasAgg
+                        && !agg.UnitMismatch
+                        && item.Varen.StandardPurchaseQuantity > 0
+                        && !string.IsNullOrEmpty(item.Varen.StandardPurchaseUnit)
+                        && !agg.Unit.IsCompatibleWith(inv.Unit.ToNorwegian()))
+                    {
+                        double invCountBase = inv.Unit.NormalizeToBaseUnit(inv.QuantityInStock);
+                        double packageInRecipeBase = MealUnitExtensions.NormalizePurchaseUnitToBase(
+                            item.Varen.StandardPurchaseQuantity, item.Varen.StandardPurchaseUnit);
+
+                        if (!double.IsNaN(invCountBase) && !double.IsNaN(packageInRecipeBase) && packageInRecipeBase > 0)
+                        {
+                            double stockInRecipeBase = invCountBase * packageInRecipeBase;
+                            double demandInBase = agg.Unit.NormalizeToBaseUnit(agg.Quantity);
+
+                            if (!double.IsNaN(demandInBase))
+                            {
+                                if (stockInRecipeBase >= demandInBase)
+                                {
+                                    item.IsLikelyNotNeeded = true;
+                                    item.IsInventoryCovered = true;
+                                }
+                                else if (stockInRecipeBase > 0)
+                                {
+                                    // Partial: convert remaining demand back from base to agg.Unit
+                                    double unitFactor = agg.Unit.NormalizeToBaseUnit(1);
+                                    if (!double.IsNaN(unitFactor) && unitFactor > 0)
+                                        item.Mengde = (int)Math.Ceiling((demandInBase - stockInRecipeBase) / unitFactor);
+                                }
+                                continue; // handled — skip same-dimension fallback
+                            }
+                        }
+                    }
+
+                    // Same-dimension (or unknown-unit) fallback: compare raw quantities directly.
                     var stock = inv.QuantityInStock;
                     if (stock >= item.Mengde)
                     {


### PR DESCRIPTION
Closes #76

GenerateShoppingList now converts inventory quantities to recipe units using StandardPurchaseQuantity before comparing against recipe demand. Items fully covered in purchase-unit terms are marked IsInventoryCovered=true / IsLikelyNotNeeded=true.

Targets integration/sprint-2-fixes.