### PR TITLE
feat: #72c smart menu suggestion UI

### DIFF
--- a/Client/Common/ISettings.cs
+++ b/Client/Common/ISettings.cs
@@ -42,7 +42,8 @@ namespace BlazorApp.Client.Common
                 { "portionrules", "api/portionrules" },
                 { "weekmenuconsume", "api/weekmenu" },
                 { "weekmenuswap", "api/weekmenu" },
-                { "weekmenuunconsume", "api/weekmenu" }
+                { "weekmenuunconsume", "api/weekmenu" },
+                { "weekmenusuggest", "api/weekmenu/suggest" }
             };
         }
         public string GetApiUrl(ShoppingListKeysEnum key)

--- a/Client/Common/ShoppingListKeysEnum.cs
+++ b/Client/Common/ShoppingListKeysEnum.cs
@@ -35,6 +35,8 @@ namespace BlazorApp.Client.Common
         WeekMenuConsume = 22,
         WeekMenuSwap = 23,
         // #81 — Undo consume
-        WeekMenuUnconsume = 24
+        WeekMenuUnconsume = 24,
+        // #72c — Smart menu suggestion
+        WeekMenuSuggest = 25
     }
 }

--- a/Client/Pages/Meals/OneWeekMenuPage.razor
+++ b/Client/Pages/Meals/OneWeekMenuPage.razor
@@ -98,6 +98,44 @@
             </div>
         </div>
 
+        @* #72c — Smart suggestion panel *@
+        <button class="btn btn-outline-secondary mt-2" @onclick="LoadSuggestions" disabled="@_loadingSuggestions">
+            @if (_loadingSuggestions)
+            {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
+            }
+            else
+            {
+                <span>🤖</span>
+            }
+            Foreslå meny
+        </button>
+
+        @if (_showSuggestions)
+        {
+            <div class="card suggestion-panel mt-2">
+                @if (_loadingSuggestions)
+                {
+                    <p class="mb-0">Laster forslag...</p>
+                }
+                else
+                {
+                    <h5>Foreslått meny</h5>
+                    @foreach (var (suggestion, index) in _suggestions.Select((s, i) => (s, i)))
+                    {
+                        <div class="suggestion-row">
+                            <span class="day-label-sm">@GetDayName(index)</span>
+                            <span>@GetCategoryIcon(suggestion.Category) @suggestion.Name</span>
+                        </div>
+                    }
+                    <div class="suggestion-actions mt-3">
+                        <button class="btn btn-primary btn-sm me-2" @onclick="AcceptSuggestions">✓ Godta forslag</button>
+                        <button class="btn btn-secondary btn-sm" @onclick="@(() => _showSuggestions = false)">Avbryt</button>
+                    </div>
+                }
+            </div>
+        }
+
         @if (_generateError != null)
         {
             <div class="alert alert-danger">@_generateError</div>
@@ -262,6 +300,11 @@
     private record UseUpSuggestion(string IngredientName, string IngredientShopItemId, List<MealRecipeModel> SuggestedMeals);
     private List<UseUpSuggestion> _useUpSuggestions = new();
     private HashSet<string> _dismissedIngredientIds = new();
+
+    // #72c — Smart suggestion state
+    private bool _showSuggestions = false;
+    private bool _loadingSuggestions = false;
+    private List<MealRecipeModel> _suggestions = new();
 
     private static readonly DayOfWeek[] WeekOrder =
     {
@@ -639,6 +682,46 @@
         MealCategory.Other       => "❓",
         _                        => "🍽️"
     };
+
+    // #72c — Smart suggestion methods
+    private async Task LoadSuggestions()
+    {
+        _loadingSuggestions = true;
+        _showSuggestions = true;
+        StateHasChanged();
+        try
+        {
+            var url = Settings.GetApiUrl(ShoppingListKeysEnum.WeekMenuSuggest);
+            _suggestions = await Http.GetFromJsonAsync<List<MealRecipeModel>>(url) ?? new();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❌ Error loading suggestions: {ex.Message}");
+            _suggestions = new();
+        }
+        _loadingSuggestions = false;
+        StateHasChanged();
+    }
+
+    private void AcceptSuggestions()
+    {
+        var days = WeekOrder.Select(d => GetOrCreateDailyMeal(d)).ToList();
+        for (int i = 0; i < Math.Min(days.Count, _suggestions.Count); i++)
+        {
+            days[i].MealRecipeId = _suggestions[i].Id;
+            days[i].MealRecipeName = _suggestions[i].Name;
+            days[i].IsSuggested = true;
+        }
+        _showSuggestions = false;
+        UpdateUseUpSuggestions();
+        StateHasChanged();
+    }
+
+    private static string GetDayName(int index) => index switch
+    {
+        0 => "Mandag", 1 => "Tirsdag", 2 => "Onsdag", 3 => "Torsdag",
+        4 => "Fredag", 5 => "Lørdag", 6 => "Søndag", _ => ""
+    };
 }
 
 <style>
@@ -676,5 +759,30 @@
         border-left: 4px solid #ffc107;
         background-color: #fffdf0;
         padding: 0.5rem 1rem;
+    }
+
+    .suggestion-panel {
+        border-left: 4px solid #6f42c1;
+        background-color: #f8f5ff;
+        padding: 0.75rem 1rem;
+    }
+
+    .suggestion-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.25rem 0;
+        border-bottom: 1px solid #e9ecef;
+    }
+
+    .suggestion-row:last-of-type {
+        border-bottom: none;
+    }
+
+    .day-label-sm {
+        width: 90px;
+        font-weight: 600;
+        white-space: nowrap;
+        color: #495057;
     }
 </style>


### PR DESCRIPTION
Part of #72

Adds '🤖 Foreslå meny' button to OneWeekMenuPage. Calls GET /api/weekmenu/suggest, shows inline suggestion panel with category icons per day, 'Godta forslag' fills week slots.

**Changes:**
- \ShoppingListKeysEnum.WeekMenuSuggest = 25\ added
- ISettings mapping: \weekmenusuggest\ → \pi/weekmenu/suggest\
- Inline suggestion panel with loading spinner, 7-day preview, Accept/Cancel actions

Targets integration/sprint-2-fixes.